### PR TITLE
cap deploy 時に puma で Rails を起動する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,8 @@
 /.bundle
 
 # Ignore all environment files (except templates).
-/.env*
-!/.env*.erb
+# /.env*
+# !/.env*.erb
 
 # Ignore all default key files.
 /config/master.key

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# サンプルアプリで secret_key_base 管理は不要
+SECRET_KEY_BASE_DUMMY=1

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 /.bundle
 
 # Ignore all environment files (except templates).
-/.env*
-!/.env*.erb
+# /.env*
+# !/.env*.erb
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Capfile
+++ b/Capfile
@@ -34,5 +34,9 @@ require "capistrano/bundler"
 require "capistrano/rails/migrations"
 # require "capistrano/passenger"
 
+require 'capistrano/puma'
+install_plugin Capistrano::Puma
+install_plugin Capistrano::Puma::Systemd
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ ENV CAPISTRANO_ROOT_DIR "/var/www/app"
 
 WORKDIR $CAPISTRANO_ROOT_DIR
 
-RUN apt-get install --no-install-recommends -y build-essential git sqlite3
+RUN apt-get install --no-install-recommends -y build-essential git curl sudo sqlite3
 
+COPY .env "${CAPISTRANO_ROOT_DIR}/shared/.env"
+COPY puma.rb "${CAPISTRANO_ROOT_DIR}/shared/puma.rb"
 COPY config/database.yml "${CAPISTRANO_ROOT_DIR}/shared/config/database.yml"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ COPY puma.rb "${CAPISTRANO_ROOT_DIR}/shared/puma.rb"
 COPY config/database.yml "${CAPISTRANO_ROOT_DIR}/shared/config/database.yml"
 
 
-EXPOSE 22
+EXPOSE 22 3000
 CMD ["/sbin/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY config/database.yml "${CAPISTRANO_ROOT_DIR}/shared/config/database.yml"
 
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+CMD ["/sbin/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ COPY .env "${CAPISTRANO_ROOT_DIR}/shared/.env"
 COPY puma.rb "${CAPISTRANO_ROOT_DIR}/shared/puma.rb"
 COPY config/database.yml "${CAPISTRANO_ROOT_DIR}/shared/config/database.yml"
 
+# systemd
+COPY docker-resources/puma.service /etc/systemd/system/puma.service
+
 
 EXPOSE 22 3000
 CMD ["/sbin/init"]

--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,6 @@ group :test do
   gem "selenium-webdriver"
 end
 
+gem 'dotenv-rails'
+
 gem "capistrano-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,5 @@ end
 gem 'dotenv-rails'
 
 gem "capistrano-rails"
+gem "capistrano3-puma", "~> 5.2"
+gem "rack", "< 3" # Puma 5 is not compatible with Rack 3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -322,6 +326,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano3-puma (5.2.0)
+      capistrano (~> 3.7)
+      capistrano-bundler
+      puma (>= 4.0, < 6.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -182,17 +186,17 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
-    puma (6.4.3)
+    puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.7)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack (2.2.9)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (2.1.0)
-      rack (>= 3)
-      webrick (~> 1.8)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
     rails (7.2.1)
       actioncable (= 7.2.1)
       actionmailbox (= 7.2.1)
@@ -324,12 +328,14 @@ DEPENDENCIES
   bootsnap
   brakeman
   capistrano-rails
+  capistrano3-puma (~> 5.2)
   capybara
   debug
   dotenv-rails
   importmap-rails
   jbuilder
   puma (>= 5.0)
+  rack (< 3)
   rails (~> 7.2.1)
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,5 @@
+class WelcomeController < ApplicationController
+  def index
+    render plain: "Welcome\n"
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,7 +12,7 @@ server "localhost",
     # forward_agent: false,
     # auth_methods: %w(publickey password)
     password: "screencast",
-    port: 5000
+    port: 4022
   }
 
 set :branch, "capistrano3-puma"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -15,7 +15,7 @@ server "localhost",
     port: 4022
   }
 
-set :branch, "capistrano3-puma"
+set :branch, (ENV["BRANCH"] || "main")
 set :production
 set :deploy_to, "/var/www/app"
 set :puma_service_unit_name, 'puma'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -15,15 +15,15 @@ server "localhost",
     port: 5000
   }
 
-set :branch, "main"
+set :branch, "capistrano3-puma"
 set :production
 set :deploy_to, "/var/www/app"
+set :puma_service_unit_name, 'puma'
 # NOTE: capistrano は non-login shell を使うので、
 #       必要な環境変数は capistrano 側で指定する必要がある
 set :default_env, {
   RAILS_ENV: :production,
-  SECRET_KEY_BASE_DUMMY: 1
 }
 
-append :linked_files, "config/database.yml"
+append :linked_files, ".env", "config/database.yml"
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,8 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
+  config.force_ssl = false
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "welcome#index"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "4000:3000"
+      - "4022:22"
+    privileged: true
+    tty: true

--- a/docker-resources/puma.service
+++ b/docker-resources/puma.service
@@ -1,0 +1,28 @@
+# cap の puma:systemd:config で生成されるのと同じもの
+
+[Unit]
+Description=Puma HTTP Server for rails7-samson-sample-client (production)
+After=network.target
+
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/var/www/app/current
+# Support older bundler versions where file descriptors weren't kept
+# See https://github.com/rubygems/rubygems/issues/3254
+ExecStart=/usr/bin/env bundle exec --keep-file-descriptors puma -C /var/www/app/shared/puma.rb
+ExecReload=/bin/kill -USR1 $MAINPID
+StandardOutput=append:/var/www/app/shared/log/puma_access.log
+StandardError=append:/var/www/app/shared/log/puma_error.log
+
+
+
+
+Restart=always
+RestartSec=1
+
+SyslogIdentifier=puma
+
+[Install]
+WantedBy=multi-user.target

--- a/puma.rb
+++ b/puma.rb
@@ -13,9 +13,9 @@ stdout_redirect '/var/www/app/shared/log/puma_access.log', '/var/www/app/shared/
 
 threads 0,16
 
+port 3000
 
-
-bind 'unix:///var/www/app/shared/tmp/sockets/puma.sock'
+# bind 'unix:///var/www/app/shared/tmp/sockets/puma.sock'
 
 workers 0
 

--- a/puma.rb
+++ b/puma.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env puma
+
+directory '/var/www/app/current'
+rackup "/var/www/app/current/config.ru"
+environment 'production'
+
+tag ''
+
+pidfile "/var/www/app/shared/tmp/pids/puma.pid"
+state_path "/var/www/app/shared/tmp/pids/puma.state"
+stdout_redirect '/var/www/app/shared/log/puma_access.log', '/var/www/app/shared/log/puma_error.log', true
+
+
+threads 0,16
+
+
+
+bind 'unix:///var/www/app/shared/tmp/sockets/puma.sock'
+
+workers 0
+
+
+
+
+restart_command 'bundle exec puma'
+
+
+prune_bundler
+
+
+on_restart do
+    puts 'Refreshing Gemfile'
+      ENV["BUNDLE_GEMFILE"] = ""
+end


### PR DESCRIPTION
cap deploy 時に puma で Rails を起動する。

その過程でいくつか関連する修正。

- docker-compose.yml 追加
- dotenv 導入
  - `SECRET_KEY_BASE_DUMMY=1` は dotenv で管理
- 仮トップページ追加
  - テキストで `Welcome` 出すだけ
